### PR TITLE
Fix compiler error in Visual Studio 2015 and small modifications of creating STL

### DIFF
--- a/SourceFiles/Bin3D.cpp
+++ b/SourceFiles/Bin3D.cpp
@@ -274,7 +274,6 @@ string Bin3D::getSTL( int offset )
     itemsInPackOrder(items);
     for( auto& i : items )
         s << i->getSTL( offset );
-    s << Shape3D::getSTL( offset );
     return s.str();
 }
 

--- a/SourceFiles/BoxPacker2D.cpp
+++ b/SourceFiles/BoxPacker2D.cpp
@@ -81,8 +81,8 @@ void BoxPacker2D::packThem( bin_v_t& ref_bins, item_v_t& items )
     {
         // randomize
         std::default_random_engine engine
-        {
-            std::chrono::system_clock::now().time_since_epoch().count() };
+        (
+            std::chrono::system_clock::now().time_since_epoch().count() );
         std::shuffle(items.begin(), items.end(), engine);
     }
 

--- a/SourceFiles/cWorld.cpp
+++ b/SourceFiles/cWorld.cpp
@@ -269,7 +269,7 @@ void cWorld::getSTL()
     for( auto& b : Bins )
     {
         s += b->getSTL( offset );
-        offset += 400;
+        offset += b->side_1()->size() * 1.5;
     }
 
     ofstream filestl("packit4me2.stl");


### PR DESCRIPTION
There is a compiler error C2398: "conversion from 'std::chrono::system_clock::rep' to 'unsigned int' requires a narrowing conversion" in Visual Studio 2015. The change solves this problem. The reason is in the way of variable initialization.

About initializers and kinds of initialization one can read [here](https://msdn.microsoft.com/en-us/library/w7wd1177.aspx).
