### PR TITLE
Fix compiler error in Visual Studio 2015

### DIFF
--- a/SourceFiles/BoxPacker2D.cpp
+++ b/SourceFiles/BoxPacker2D.cpp
@@ -81,8 +81,8 @@ void BoxPacker2D::packThem( bin_v_t& ref_bins, item_v_t& items )
     {
         // randomize
         std::default_random_engine engine
-        {
-            std::chrono::system_clock::now().time_since_epoch().count() };
+        (
+            std::chrono::system_clock::now().time_since_epoch().count() );
         std::shuffle(items.begin(), items.end(), engine);
     }
 


### PR DESCRIPTION
There is a compiler error C2398: "conversion from 'std::chrono::system_clock::rep' to 'unsigned int' requires a narrowing conversion" in Visual Studio 2015. The change solves this problem. The reason is in the way of variable initialization.
