### PR TITLE
The distance between bins in STL

### DIFF
--- a/SourceFiles/cWorld.cpp
+++ b/SourceFiles/cWorld.cpp
@@ -269,7 +269,7 @@ void cWorld::getSTL()
     for( auto& b : Bins )
     {
         s += b->getSTL( offset );
-        offset += 400;
+        offset += b->side_1()->size() * 1.5;
     }
 
     ofstream filestl("packit4me2.stl");


### PR DESCRIPTION
Changed distance between bins in STL from 400 to half side1 of the bin, because if side1 of the bin is greater than 400 the next bin will be overlaped.
