### PR TITLE
Bug in Item3D::IsAboveBelow

### DIFF
--- a/SourceFiles/Item3D.cpp
+++ b/SourceFiles/Item3D.cpp
@@ -126,7 +126,7 @@ bool Item3D::IsAboveBelow( item_t other )
     double ow1 = other->getWLocation();
     double ow2 = ow1 + other->side_1()->size() - 1;
     double ol1 = other->getLLocation();
-    double ol2 = ow2 + other->side_3()->size() - 1;
+    double ol2 = ol1 + other->side_3()->size() - 1;
 
 
 //    cout << mw1 <<" "<< mw2 <<" "<< ml1 <<" "<< ml2 <<"\n"<<

--- a/unit_test/unit_test.cpp
+++ b/unit_test/unit_test.cpp
@@ -204,21 +204,21 @@ TEST( AboveBelow )
     i1->set_side_3( new Side( 3, 'l'  ) );
     i1->setWLocation(0);
     i1->setHLocation(0);
-    i1->setLLocation(0);
+    i1->setLLocation(7);
     std::shared_ptr<Item> i2( new Item3D() );
     i2->set_side_1( new Side( 1, 'w' ));
     i2->set_side_2( new Side( 2, 'h'  ) );
     i2->set_side_3( new Side( 3, 'l'  ) );
     i2->setWLocation(0);
     i2->setHLocation(200);
-    i2->setLLocation(0);
+    i2->setLLocation(5);
     std::shared_ptr<Item> i3( new Item3D() );
     i3->set_side_1( new Side( 1, 'w' ));
     i3->set_side_2( new Side( 2, 'h'  ) );
     i3->set_side_3( new Side( 3, 'l'  ) );
     i3->setWLocation(220);
     i3->setHLocation(0);
-    i3->setLLocation(0);
+    i3->setLLocation(5);
 
     std::shared_ptr<Bin> bin( new Bin3D );
     i1->setBin( bin->Root( bin )->progid() );

--- a/unit_test/unit_test.cpp
+++ b/unit_test/unit_test.cpp
@@ -204,21 +204,21 @@ TEST( AboveBelow )
     i1->set_side_3( new Side( 3, 'l'  ) );
     i1->setWLocation(0);
     i1->setHLocation(0);
-    i1->setLLocation(7);
+    i1->setLLocation(0);
     std::shared_ptr<Item> i2( new Item3D() );
     i2->set_side_1( new Side( 1, 'w' ));
     i2->set_side_2( new Side( 2, 'h'  ) );
     i2->set_side_3( new Side( 3, 'l'  ) );
     i2->setWLocation(0);
     i2->setHLocation(200);
-    i2->setLLocation(5);
+    i2->setLLocation(0);
     std::shared_ptr<Item> i3( new Item3D() );
     i3->set_side_1( new Side( 1, 'w' ));
     i3->set_side_2( new Side( 2, 'h'  ) );
     i3->set_side_3( new Side( 3, 'l'  ) );
     i3->setWLocation(220);
     i3->setHLocation(0);
-    i3->setLLocation(5);
+    i3->setLLocation(0);
 
     std::shared_ptr<Bin> bin( new Bin3D );
     i1->setBin( bin->Root( bin )->progid() );
@@ -269,6 +269,27 @@ TEST( OverlapArea )
      CHECK_CLOSE( i3->AreaWidthLength() / 2, i3->OverlapArea( i2 ), 0.1 );
 
 }
+
+TEST(AboveBelowBug)
+{
+	std::shared_ptr<Item> i1(new Item3D());
+	i1->set_side_1(new Side(1, 'w'));
+	i1->set_side_2(new Side(2, 'h'));
+	i1->set_side_3(new Side(3, 'l'));
+	i1->setWLocation(0);
+	i1->setHLocation(0);
+	i1->setLLocation(7);
+	std::shared_ptr<Item> i2(new Item3D());
+	i2->set_side_1(new Side(1, 'w'));
+	i2->set_side_2(new Side(2, 'h'));
+	i2->set_side_3(new Side(3, 'l'));
+	i2->setWLocation(0);
+	i2->setHLocation(200);
+	i2->setLLocation(5);
+
+	CHECK(i1->IsAboveBelow(i2));
+}
+
 int main(int argc, char *argv[])
 {
     return raven::set::UnitTest::RunAllTests();


### PR DESCRIPTION
When calculating `ol2` there must be `ol1` instead of `ow2`
